### PR TITLE
Removendo opção UNDEFINED de BillingType

### DIFF
--- a/src/main/groovy/utils/payment/BillingType.groovy
+++ b/src/main/groovy/utils/payment/BillingType.groovy
@@ -6,6 +6,5 @@ public enum BillingType {
     DEPOSIT,
     TRANSFER,
     DEBIT_CARD,
-    CREDIT_CARD,
-    UNDEFINED
+    CREDIT_CARD
 }


### PR DESCRIPTION
### Impacto

- Removido a opção de UNDEFINED como uma forma de pagamento

Motivo: Essa opção não se encaixa com nosso sistema atual. 

### Release Note (Descrição que irá no forno)

### PR Predecessora

### Plano de deploy
- Antes do deploy:
- Depois do deploy:

### Link da tarefa no JIRA

### Link dos mockups

### Prints do desenvolvimento
