### PR TITLE
Impedindo o soft delete de um  payer com cobrança pendente | Payer

### DIFF
--- a/grails-app/domain/com/quickcharge/app/payment/Payment.groovy
+++ b/grails-app/domain/com/quickcharge/app/payment/Payment.groovy
@@ -35,7 +35,7 @@ class Payment extends BaseEntity {
             if (search.containsKey("id")) {
                 eq("id", Long.valueOf(search.id))
             }
-            
+
             if (search.containsKey("customerId")) {
                 eq("customer.id", Long.valueOf(search.customerId))
             }
@@ -52,6 +52,10 @@ class Payment extends BaseEntity {
             
             if (search.containsKey("includePendingPayments")) {
                 eq("status", PaymentStatus.PENDING)
+            }
+
+            if (search.containsKey("payerId")) {
+                eq("payer.id", Long.valueOf(search.payerId))
             }
         }
     }

--- a/grails-app/domain/com/quickcharge/app/payment/Payment.groovy
+++ b/grails-app/domain/com/quickcharge/app/payment/Payment.groovy
@@ -50,7 +50,7 @@ class Payment extends BaseEntity {
                 lt("dueDate", search."dueDate[lt]")
             }
             
-            if (search.containsKey("includePendingPayments")) {
+            if (search.containsKey("onlyPendingPayments")) {
                 eq("status", PaymentStatus.PENDING)
             }
 

--- a/grails-app/i18n/messages_pt_BR.properties
+++ b/grails-app/i18n/messages_pt_BR.properties
@@ -110,3 +110,5 @@ past.date.com.quickcharge.app.payment.Payment.dueDate=Data de vencimento não po
 delete.payed.com.quickcharge.app.payment.Payment.dueDate=Não é possivel remover uma cobrança já paga
 
 already.received.com.quickcharge.app.payment.Payment.status=Não é possível alterar cobrança já recebida
+
+pending.payment.com.quickcharge.app.payer.Payer.id=Não é possível excluir um cliente com uma cobrança pendente

--- a/grails-app/services/com/quickcharge/app/payer/PayerService.groovy
+++ b/grails-app/services/com/quickcharge/app/payer/PayerService.groovy
@@ -73,8 +73,6 @@ class PayerService {
 
         Long customerId = Long.valueOf(springSecurityService.getCurrentUser().customer.id)
         Payer payer = Payer.query([id: parameterMap.id, customerId: customerId]).get()
-
-        List<Payment> paymentList = Payment.query([payerId: payer.id, onlyPendingPayments: true]).list()
         
         payer.deleted = true
         
@@ -109,8 +107,16 @@ class PayerService {
         Payer validatedPayer = new Payer()
 
         Long customerId = Long.valueOf(springSecurityService.getCurrentUser().customer.id)
-        if (!Payer.query([id: parameterMap.id, customerId: customerId]).get()) {
+
+        validatedPayer = Payer.query([id: parameterMap.id, customerId: customerId]).get()
+        
+        if (!validatedPayer) {
             validatedPayer.errors.rejectValue("id", "not.found")
+        }
+        
+        List<Payment> pendingPaymentList = Payment.query([customerId: customerId, payerId: validatedPayer.id, onlyPendingPayments: true]).list()
+        if (!pendingPaymentList.isEmpty()) {
+            validatedPayer.errors.rejectValue("id", "pending.payment")
         }
         
         return validatedPayer

--- a/grails-app/services/com/quickcharge/app/payer/PayerService.groovy
+++ b/grails-app/services/com/quickcharge/app/payer/PayerService.groovy
@@ -1,6 +1,7 @@
 package com.quickcharge.app.payer
 
 import com.quickcharge.app.customer.Customer
+import com.quickcharge.app.payment.Payment
 import grails.gorm.transactions.Transactional
 import grails.validation.ValidationException
 import utils.CpfCnpjUtils
@@ -72,6 +73,9 @@ class PayerService {
 
         Long customerId = Long.valueOf(springSecurityService.getCurrentUser().customer.id)
         Payer payer = Payer.query([id: parameterMap.id, customerId: customerId]).get()
+
+        List<Payment> paymentList = Payment.query([payerId: payer.id, onlyPendingPayments: true]).list()
+        
         payer.deleted = true
         
         return payer.save(failOnError: true)

--- a/grails-app/services/com/quickcharge/app/payment/PaymentService.groovy
+++ b/grails-app/services/com/quickcharge/app/payment/PaymentService.groovy
@@ -99,7 +99,7 @@ class PaymentService {
     }
 
     public void processPaymentOverdue() {
-        List<Long> overduePendingPaymentsIdList = Payment.query(["column": "id", "dueDate[lt]": new Date(), "includePendingPayments": true]).list()
+        List<Long> overduePendingPaymentsIdList = Payment.query(["column": "id", "dueDate[lt]": new Date(), "onlyPendingPayments": true]).list()
 
         if (overduePendingPaymentsIdList.isEmpty()) return
 


### PR DESCRIPTION
### Impacto
Impedindo o soft delete de um  payer com cobrança pendente.
- Caso tente excluir o payer e tenha uma cobrança ainda pendente, irá aparecer a mensagem: 
 **Não é possível excluir um cliente com uma cobrança pendente**
### Release Note (Descrição que irá no forno)

### PR Predecessora
#50 
### Plano de deploy
- Antes do deploy:
- Depois do deploy:

### Link da tarefa no JIRA

### Link dos mockups

### Prints do desenvolvimento
