### PR TITLE
Refatorando formulários para Atlas |Payment 

### DIFF
--- a/grails-app/services/com/quickcharge/app/payment/PaymentService.groovy
+++ b/grails-app/services/com/quickcharge/app/payment/PaymentService.groovy
@@ -109,8 +109,8 @@ class PaymentService {
         Long paymentId = parameterMap.long("id")
         Payment payment = Payment.getById(paymentId, customerId)
 
-        Double value = parameterMap.double("value")
-        Date dueDate = new SimpleDateFormat("yyyy-MM-dd").parse(parameterMap.dueDate as String)
+        Double value = Utils.toBigDecimalFormatted(parameterMap.value as String).toDouble()
+        Date dueDate = new SimpleDateFormat("dd/MM/yyyy").parse(parameterMap.dueDate as String)
 
         payment.value = value
         payment.dueDate = dueDate
@@ -121,7 +121,7 @@ class PaymentService {
     public Payment validateUpdate(String dueDate) {
         Payment validatedPayment = new Payment()
 
-        SimpleDateFormat simpleDate = new SimpleDateFormat("yyyy-MM-dd")
+        SimpleDateFormat simpleDate = new SimpleDateFormat("dd/MM/yyyy")
         Date dueDateValidate = simpleDate.parse(dueDate)
         if(dueDateValidate.before(simpleDate.parse(simpleDate.format(new Date())))) {
             validatedPayment.errors.rejectValue("dueDate", "past.date")

--- a/grails-app/services/com/quickcharge/app/payment/PaymentService.groovy
+++ b/grails-app/services/com/quickcharge/app/payment/PaymentService.groovy
@@ -5,6 +5,7 @@ import com.quickcharge.app.payer.Payer
 import grails.gorm.transactions.Transactional
 import grails.validation.ValidationException
 import org.apache.commons.lang3.EnumUtils
+import utils.Utils
 import utils.payment.BillingType
 import utils.payment.PaymentStatus
 import java.text.SimpleDateFormat
@@ -22,8 +23,8 @@ class PaymentService {
         Payment payment = new Payment()
         Payer payer = Payer.query([id: parameterMap.payerId, customerId: customer.id]).get()
         BillingType billingType = BillingType[parameterMap.billingType as String] as BillingType
-        Double value = parameterMap.double("value")
-        Date dueDate = new SimpleDateFormat("yyyy-MM-dd").parse(parameterMap.dueDate as String) 
+        Double value = Utils.toBigDecimalFormatted(parameterMap.value as String).toDouble()
+        Date dueDate = new SimpleDateFormat("dd/MM/yyyy").parse(parameterMap.dueDate as String) 
         
         payment.payer = payer
         payment.customer = customer
@@ -50,8 +51,8 @@ class PaymentService {
             return validatedPayment
         }
 
-        SimpleDateFormat simpleDate = new SimpleDateFormat("yyyy-MM-dd")
-        Date dueDate = simpleDate.parse(parameterMap.dueDate as String)
+        SimpleDateFormat simpleDate = new SimpleDateFormat("dd/MM/yyyy")
+        Date dueDate = simpleDate.parse(parameterMap.dueDate)
         if(dueDate.before(simpleDate.parse(simpleDate.format(new Date())))) {
             validatedPayment.errors.rejectValue("dueDate", "past.date")
         }

--- a/grails-app/views/payment/create.gsp
+++ b/grails-app/views/payment/create.gsp
@@ -6,29 +6,43 @@
 
     <body>
         <g:message code="${flash.message}"/>
-        <form action="${createLink(controller: "payment", action: "save")}" method="post">
+        <atlas-form action="${createLink(controller: "payment", action: "save")}" method="post">
+            <atlas-layout gap="4">
+                <atlas-select label="Cliente"
+                              name="payerId"
+                              required>
+                    <g:each var="payer" in="${payerList}">
+                        <atlas-option
+                            label="${payer.name}"
+                            value="${payer.id}"></atlas-option>
+                    </g:each>
+                </atlas-select>
 
-            <label for="payerId">Pagador</label>
-            <g:select name="payerId" id="payerId" from="${payerList}" optionValue="name" optionKey="id"
-                      noSelection="['': 'Selecione o pagador']" value="${params.payerId}"/>
-            <br>
+                <atlas-money
+                    label="Valor da cobrança"
+                    name="value"
+                    min-value="5"
+                    min-value-error-message="O valor mínimo é 5 reais"
+                    required></atlas-money>
 
-            <label for="billingType">Forma de pagamento</label>
-            <g:select name="billingType" id="billingType" from="${billingType}" valueMessagePrefix="ENUM.BillingType"
-                      noSelection="['': 'Selecione a forma de pagamento']" value="${params.billingType}"/>
-            <br>
+                <atlas-select label="Forma de pagamento"
+                              name="billingType"
+                              required>
+                    <g:each var="type" in="${billingType}">
+                        <atlas-option
+                            label="${message(code: 'ENUM.BillingType.' + type.toString())}"
+                            value="${type}"></atlas-option>
+                    </g:each>
+                </atlas-select>
 
-            <label for="value">Valor da cobrança</label>
-            <input type="number" min="0.01" step="any" name="value" id="value" value="${params.value}"
-                   placeholder="Digite o valor da cobrança">
-            <br>
+                <atlas-datepicker label="Data de vencimento"
+                                  icon="calendar"
+                                  required-error-message="Necessário preencher"
+                                  required
+                                  name="dueDate"></atlas-datepicker>
 
-            <label for="dueDate">Data de vencimento</label>
-            <input type="date" name="dueDate" id="dueDate" value="${params.dueDate}"
-                   placeholder="Insira a data de vencimento">
-            <br>
-
-            <button type="submit">Criar cobrança</button>
-        </form>
+                <atlas-button submit description="Criar Cobrança"></atlas-button>
+            </atlas-layout>
+        </atlas-form>
     </body>
 </html>

--- a/grails-app/views/payment/create.gsp
+++ b/grails-app/views/payment/create.gsp
@@ -38,10 +38,11 @@
                 </atlas-select>
 
                 <atlas-datepicker label="Data de vencimento"
+                                  name="dueDate"
                                   icon="calendar"
                                   required-error-message="Necessário preencher"
-                                  required
-                                  name="dueDate"></atlas-datepicker>
+                                  prevent-past-date
+                                  required></atlas-datepicker>
 
                 <atlas-button submit description="Criar Cobrança"></atlas-button>
             </atlas-layout>

--- a/grails-app/views/payment/edit.gsp
+++ b/grails-app/views/payment/edit.gsp
@@ -28,7 +28,6 @@
                             min-value-error-message="O valor mínimo é 5 reais"
                             required></atlas-money>
 
-
                         <atlas-input
                             label="Forma de pagamento"
                             value="${message(code: 'ENUM.BillingType.' + payment.billingType.toString())}"

--- a/grails-app/views/payment/edit.gsp
+++ b/grails-app/views/payment/edit.gsp
@@ -6,37 +6,46 @@
 
     <body>
         <%@ page import="utils.payment.BillingType" %>
-        
+
         <main>
             <g:message code="${flash.message}"/>
             <g:if test="${payment}">
-                <form action="${createLink(controller: "payment", action: "update")}" method="post">
-                    <input type="hidden" name="id" value="${payment.id}">
+                <atlas-form action="${createLink(controller: "payment", action: "update")}" method="post">
+                    <atlas-layout gap="4">
+                        <atlas-input type="hidden" name="id" value="${payment.id}"></atlas-input>
 
-                    <label for="payerId">Cliente</label>
-                    <input type="text" name="payerId" id="payerId" value="${payment.payer.name}" disabled="">
-                    <br>
+                        <atlas-input
+                            label="Cliente"
+                            value="${payment.payer.name}"
+                            required
+                            disabled></atlas-input>
 
-                    <label for="billingType">Forma de pagamento</label>
-                    <g:select name="billingType" id="billingType"
-                              from="${BillingType.values()}"
-                              valueMessagePrefix="ENUM.BillingType"
-                              value="${payment.billingType}"
-                              disabled=""/>
-                    <br>
+                        <atlas-money
+                            label="Valor da cobrança"
+                            value="${payment.value}"
+                            name="value"
+                            min-value="5"
+                            min-value-error-message="O valor mínimo é 5 reais"
+                            required></atlas-money>
 
-                    <label for="value">Valor da cobrança</label>
-                    <input type="number" min="0.01" step="any" name="value" id="value" value="${payment.value}"
-                           placeholder="Digite o valor da cobrança">
-                    <br>
 
-                    <label for="dueDate">Data de vencimento</label>
-                    <input type="date" name="dueDate" id="dueDate"
-                           value="${g.formatDate(format: "dd/MM/yyyy", date: payment.dueDate)}">
-                    <br>
+                        <atlas-input
+                            label="Forma de pagamento"
+                            value="${message(code: 'ENUM.BillingType.' + payment.billingType.toString())}"
+                            required
+                            disabled></atlas-input>
 
-                    <button type="submit">Salvar</button>
-                </form>
+                        <atlas-datepicker label="Data de vencimento"
+                                          value="${g.formatDate(format: "dd/MM/yyyy", date: payment.dueDate)}}"
+                                          name="dueDate"
+                                          icon="calendar"
+                                          prevent-past-date
+                                          required-error-message="Necessário preencher"
+                                          required></atlas-datepicker>
+
+                        <atlas-button submit description="Salvar Cobrança"></atlas-button>
+                    </atlas-layout>
+                </atlas-form>
             </g:if>
         </main>
     </body>

--- a/src/main/groovy/utils/Utils.groovy
+++ b/src/main/groovy/utils/Utils.groovy
@@ -24,4 +24,8 @@ class Utils {
         final Pattern STATE_PATTERN = ~/[A-Z]{2}/
         return state.matches(STATE_PATTERN)
     }
+    
+    public static BigDecimal toBigDecimalFormatted(String value) {
+        return new BigDecimal(value.replaceAll('\\.', "").replaceAll(',', "."))
+    }
 }


### PR DESCRIPTION
### Impacto
Refatoração dos formulários de **criação** e **edição** de cobranças para atlas.
- Foi necessário alterar a forma que a validação do dueDate funcionava na service: 
    - Como agora é recebido uma string de data, a tratativa precisa ser diferente. Futuramente devemos considerar mudar o campo de Double para BigDecimal.

### Release Note (Descrição que irá no forno)

### PR Predecessora

### Plano de deploy
- Antes do deploy:
- Depois do deploy:

### Link da tarefa no JIRA

### Link dos mockups

### Prints do desenvolvimento

![create](https://github.com/JezVini/quickCharge/assets/130087613/fa34f4a0-6bd0-4b67-b927-0825382c835f)
![edit](https://github.com/JezVini/quickCharge/assets/130087613/24c79ee5-4024-439d-a72a-2536279158d9)

