### PR TITLE
Criação de TagLib para formatações em GSP

### DIFF
--- a/grails-app/taglib/quickcharge/utils/UtilsTagLib.groovy
+++ b/grails-app/taglib/quickcharge/utils/UtilsTagLib.groovy
@@ -1,0 +1,27 @@
+package quickcharge.utils
+
+import utils.Utils
+
+class UtilsTagLib {
+
+    def formatNumberSeparatorWithComma = { attrs ->
+        out << Utils.formatNumberSeparatorWithComma(attrs.value as Double)
+    }
+
+    def formatMonetaryValue = { attrs ->
+        String valueWithComma = Utils.formatNumberSeparatorWithComma(attrs.value as Double)
+        out << 'R$ ' + valueWithComma
+    }
+
+    def formatCpfCnpj = { attrs ->
+        out << Utils.formatCpfCnpj(attrs.value as String)
+    }
+    
+    def formatPhone = { attrs ->
+        out << Utils.formatPhone(attrs.value as String)
+    }
+
+    def formatCep = { attrs ->
+        out << Utils.formatCep(attrs.value as String)
+    }
+}

--- a/grails-app/views/payer/edit.gsp
+++ b/grails-app/views/payer/edit.gsp
@@ -32,7 +32,7 @@
                     mask-alias="cpf-cnpj"
                     label="CPF ou CNPJ"
                     name="cpfCnpj"
-                    value="${payer.cpfCnpj}"
+                    value="<g:formatCpfCnpj value='${payer.cpfCnpj}'/>"
                     size="md"
                     required></atlas-masked-input>
 
@@ -40,14 +40,14 @@
                     mask-alias="phone"
                     label="Telefone ou celular"
                     name="phone"
-                    value="${payer.phone}"
+                    value="<g:formatPhone value='${payer.phone}'/>"
                     size="md"
                     required></atlas-masked-input>
 
                 <atlas-postal-code
                     label="CEP"
                     name="postalCode"
-                    value="${payer.postalCode}"
+                    value="<g:formatCep value='${payer.postalCode}'/>"
                     size="md"
                     required
                     disable-search

--- a/grails-app/views/payment/edit.gsp
+++ b/grails-app/views/payment/edit.gsp
@@ -13,7 +13,7 @@
                 <atlas-form action="${createLink(controller: "payment", action: "update")}" method="post">
                     <atlas-layout gap="4">
                         <atlas-input type="hidden" name="id" value="${payment.id}"></atlas-input>
-
+                        
                         <atlas-input
                             label="Cliente"
                             value="${payment.payer.name}"
@@ -22,7 +22,7 @@
 
                         <atlas-money
                             label="Valor da cobrança"
-                            value="${payment.value}"
+                            value="<g:formatNumberSeparatorWithComma value='${payment.value}'/>"
                             name="value"
                             min-value="5"
                             min-value-error-message="O valor mínimo é 5 reais"

--- a/src/main/groovy/utils/Utils.groovy
+++ b/src/main/groovy/utils/Utils.groovy
@@ -1,6 +1,7 @@
 package utils
 
 import javax.swing.text.MaskFormatter
+import java.text.DecimalFormat
 import java.util.regex.Pattern
 
 class Utils {
@@ -42,5 +43,17 @@ class Utils {
         MaskFormatter maskFormatter = new MaskFormatter(mask)
         maskFormatter.setValueContainsLiteralCharacters(false)
         return maskFormatter.valueToString(cpfCnpj)
+    }
+    
+    public static String formatNumberSeparatorWithComma(Double value) {
+        DecimalFormat decimalFormat = new DecimalFormat("0.00")
+        return decimalFormat.format(value)
+    }
+
+    public static String formatCep(String cep) {
+        String mask = "#####-###"
+        MaskFormatter maskFormatter = new MaskFormatter(mask)
+        maskFormatter.setValueContainsLiteralCharacters(false)
+        return maskFormatter.valueToString(cep)
     }
 }


### PR DESCRIPTION
### Impacto
Criação e implementação da TagLib com métodos para formatar os seguintes valores:
- Transformar números decimais para strings com vírgula
- Adicionar R$ a frente de valores formatados
- Formatação de cep e telefone

### Release Note (Descrição que irá no forno)

### PR Predecessora

### Plano de deploy
- Antes do deploy:
- Depois do deploy:

### Link da tarefa no JIRA

### Link dos mockups

### Prints do desenvolvimento
