### PR TITLE
Adicionando títulos dinâmicos

### DIFF
--- a/grails-app/taglib/quickcharge/BreadcrumbTagLib.groovy
+++ b/grails-app/taglib/quickcharge/BreadcrumbTagLib.groovy
@@ -4,9 +4,13 @@ class BreadcrumbTagLib {
     static namespace = "breadcrumb"
 
     def render = { attrs ->
-        List<Map> breadcrumbList = generateBreadcrumbList()
+        out << g.render(template: "/shared/templates/breadcrumb", model: [breadcrumbList: flash.breadcrumbList])
+    }
 
-        out << g.render(template: "/shared/templates/breadcrumb", model: [breadcrumbList: breadcrumbList])
+    def activePageName = { attrs ->
+        List<Map> breadcrumbList = generateBreadcrumbList()
+        flash.breadcrumbList = breadcrumbList
+        out << (!breadcrumbList.isEmpty() ? breadcrumbList.get(breadcrumbList.size() - 1).name : "").toString()
     }
 
     private List<Map> generateBreadcrumbList() {

--- a/grails-app/views/layouts/main.gsp
+++ b/grails-app/views/layouts/main.gsp
@@ -30,7 +30,7 @@
         <atlas-screen>
             <sideBar:render/>
             <atlas-page>
-                <atlas-page-header slot="header" page-name="">
+            <atlas-page-header slot="header" page-name="<breadcrumb:activePageName/>"></atlas-page-header>
                 </atlas-page-header>
                 <atlas-page-content slot="content" class="js-atlas-content">
                     <alertTagLib:renderAlert/>


### PR DESCRIPTION
### Impacto
Adição de títulos nas páginas de forma dinâmica, o título se baseia no último item em ativo no breadcrumb.

### Release Note (Descrição que irá no forno)

### PR Predecessora

### Plano de deploy
- Antes do deploy:
- Depois do deploy:

### Link da tarefa no JIRA

### Link dos mockups

### Prints d
![dynamic-title](https://github.com/JezVini/quickCharge/assets/130087613/8fb34db7-3a4c-4a5a-9c15-f833e6aadcb7)
o desenvolvimento
